### PR TITLE
Remove message that at least one entrypoint is required

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/common/Mod.java
+++ b/loader/src/main/java/net/neoforged/fml/common/Mod.java
@@ -15,7 +15,7 @@ import net.neoforged.api.distmarker.Dist;
  * This defines a Mod to FML.
  * <p>
  * Any class found with this annotation applied will be loaded as a mod entrypoint for the mod with the given {@linkplain #value() ID}. <br>
- * A mod loaded with the {@code javafml} language loader may have multiple entrypoints, but it must have <strong>at least one</strong>.
+ * A mod loaded with the {@code javafml} language loader may have multiple entrypoints.
  * Entrypoints for all {@link #dist}s are always run before entrypoints for a single {@link #dist}.
  */
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
This is no longer a requirement.